### PR TITLE
feat!: removed unnecessary_await_in_return

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ We love the rules from `very_good_analysis`, but we wanted to make some changes 
 
 - **No `prefer_single_quotes`**, since not all of our devs use US keyboard layouts, and it's not easier to type single quotes on most other layouts. Instead, we gain the benefit of never having to think about whether to use single or double quotes. We also don't have to worry about escaping quotes in strings.
 - **Allow `one_member_abstracts`**, since sometimes we need to define interfaces in the domain layer that need to be implemented in the data layer. They should be allowed even with one member. Top level functions don't work for this usecase.
+- **No `unnecessary_await_in_return`** since it can mess with error catching if not used carefully (see [this issue](https://github.com/dart-lang/linter/issues/2357))
 - We also exclude a bunch of generated file types from the lint rules.
 
 ---

--- a/lib/analysis_options.0.2.0.yaml
+++ b/lib/analysis_options.0.2.0.yaml
@@ -1,0 +1,14 @@
+include: package:very_good_analysis/analysis_options.5.1.0.yaml
+
+analyzer:
+  exclude:
+    - "**/*.freezed.dart"
+    - "**/*.g.dart"
+    - test/.test_coverage.dart
+    - lib/generated_plugin_registrant.dart
+
+linter:
+  rules:
+    prefer_single_quotes: false
+    one_member_abstracts: false
+    unnecessary_await_in_return: false

--- a/lib/analysis_options.yaml
+++ b/lib/analysis_options.yaml
@@ -1,1 +1,1 @@
-include: ./analysis_options.0.1.0.yaml
+include: ./analysis_options.0.2.0.yaml


### PR DESCRIPTION


## Description
Removes the `unnecessary_await_in_return` linter rule

Fixes #3

## Checklist

<!--- Put an `x` in all the boxes that apply: -->
- [X] My PR title is in the style of [conventional commits](https://www.conventionalcommits.org/)
- [X] All public facing APIs are documented with [dartdoc](https://dart.dev/guides/language/effective-dart/documentation)
- [ ] I have added tests to cover my changes
